### PR TITLE
Fix incorrect comment for RememberedEffect in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Unlike `LaunchedEffect`, `RememberEffect` does not create or launch a new corout
 ```kotlin
 var count by remember { mutableIntStateOf(0) }
 
- // It will launch a new coroutine scope regardless the task is related to the coroutines.
+// Unlike LaunchedEffect, this won't launch a new coroutine scope when the key changes.
 RememberEffect(key1 = count) {
     Log.d(tag, "$count")
 }


### PR DESCRIPTION
First of all, thank you for creating this library! 

While reading through the README, I noticed a small inconsistency in the RememberedEffect section. The main description correctly explains that unlike LaunchedEffect, RememberedEffect doesn't create or launch a new coroutine scope on each key change. However, the comment in the code example states the opposite: "It will launch a new coroutine scope regardless the task is related to the coroutines."

I've updated the comment to align with the actual behavior described in the explanation above.

Thank you again for this valuable contribution to the Compose ecosystem!