### PR TITLE
Prevent usage of RememberedEffect without key

### DIFF
--- a/compose-effects/api/android/compose-effects.api
+++ b/compose-effects/api/android/compose-effects.api
@@ -2,6 +2,7 @@ public final class com/skydoves/compose/effects/RememberedEffectKt {
 	public static final fun RememberedEffect (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RememberedEffect (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RememberedEffect (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun RememberedEffect (Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RememberedEffect ([Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 }
 

--- a/compose-effects/api/desktop/compose-effects.api
+++ b/compose-effects/api/desktop/compose-effects.api
@@ -2,6 +2,7 @@ public final class com/skydoves/compose/effects/RememberedEffectKt {
 	public static final fun RememberedEffect (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RememberedEffect (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RememberedEffect (Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun RememberedEffect (Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun RememberedEffect ([Ljava/lang/Object;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 }
 

--- a/compose-effects/src/commonMain/kotlin/com/skydoves/compose/effects/RememberedEffect.kt
+++ b/compose-effects/src/commonMain/kotlin/com/skydoves/compose/effects/RememberedEffect.kt
@@ -21,6 +21,19 @@ import androidx.compose.runtime.NonRestartableComposable
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.remember
 
+private const val RememberedEffectNoParamError =
+  "RememberedEffect must provide one or more 'key' parameters."
+
+/**
+ * It is an error to call [RememberedEffect] without at least one `key` parameter.
+ */
+// This deprecated-error function shadows the varargs overload so that the varargs version
+// is not used without key parameters.
+@Deprecated(RememberedEffectNoParamError, level = DeprecationLevel.ERROR)
+@Suppress("DeprecatedCallableAddReplaceWith", "UNUSED_PARAMETER")
+@Composable
+public fun RememberedEffect(effect: () -> Unit): Unit = error(RememberedEffectNoParamError)
+
 /**
  * `RememberEffect` is a side-effect API that executes the provided [effect] lambda when it enters
  * the composition and re-executes it whenever [key1] changes.


### PR DESCRIPTION
### 🎯 Goal
Prevent incorrect usage of RememberedEffect by enforcing at least one key parameter, similar to how LaunchedEffect works.

### 🛠 Implementation details
Added a deprecated no-parameter overload of RememberedEffect that triggers a compile-time error when called without keys. This mimics the safeguard used in LaunchedEffect to avoid misuse caused by empty vararg.

### ✍️ Explain examples
```
// ✅ Correct usage
RememberedEffect(key1) { ... }

// ❌ Incorrect usage (will trigger compile error)
RememberedEffect { ... }
```

### Preparing a pull request for review
Ensure your change is properly formatted by running:

✅ spotlessApply
```bash
$ ./gradlew spotlessApply
```

Then dump binary APIs of this library that is public in sense of Kotlin visibilities and ensures that the public binary API wasn't changed in a way that makes this change binary incompatible.

✅ apiDump
```bash
./gradlew apiDump
```

Please correct any failures before requesting a review.

## Code reviews
All submissions, including submissions by project members, require review. We use GitHub pull requests for this purpose. Consult [GitHub Help](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests) for more information on using pull requests.
